### PR TITLE
fix: trim hex prefix from snap

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/snapdao/btcsnap"
   },
   "source": {
-    "shasum": "I0CtOOJ29joWvXheiqgadBCnfzOmbmvpIErWWgy3xtU=",
+    "shasum": "MS7p3iuoz09Z0nHFMeJuvVXcmUY+dK7YUuaqisaZ4v4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/rpc/getExtendedPublicKey.ts
+++ b/packages/snap/src/rpc/getExtendedPublicKey.ts
@@ -3,7 +3,7 @@ import { BIP32Interface } from 'bip32';
 import { Network, networks } from 'bitcoinjs-lib';
 import { BitcoinNetwork, ScriptType, SLIP10Node, Wallet } from '../interface';
 import { convertXpub } from "../bitcoin/xpubConverter";
-import { getPersistedData, updatePersistedData } from '../utils/manageState';
+import { getPersistedData, updatePersistedData, trimHexPrefix } from '../utils';
 import { RequestErrors, SnapError } from "../errors";
 
 export const pathMap: Record<ScriptType, string[]> = {
@@ -28,8 +28,8 @@ export async function extractAccountPrivateKey(wallet: Wallet, network: Network,
         },
     }) as SLIP10Node
 
-    const privateKeyBuffer = Buffer.from(slip10Node.privateKey, "hex")
-    const chainCodeBuffer = Buffer.from(slip10Node.chainCode, "hex")
+    const privateKeyBuffer = Buffer.from(trimHexPrefix(slip10Node.privateKey), "hex")
+    const chainCodeBuffer = Buffer.from(trimHexPrefix(slip10Node.chainCode), "hex")
     const node: BIP32Interface = bip32.fromPrivateKey(privateKeyBuffer, chainCodeBuffer, network)
     //@ts-ignore 
     // ignore checking since no function to set depth for node

--- a/packages/snap/src/utils/__tests__/hexHelper.test.ts
+++ b/packages/snap/src/utils/__tests__/hexHelper.test.ts
@@ -1,0 +1,13 @@
+import { trimHexPrefix } from '../hexHelper';
+
+describe('hexHelper', () => {
+  describe('trimHexPrefix', () => {
+    it('should trim prefix 0x given a string start with 0x', () => {
+      expect(trimHexPrefix('0x12345678')).toBe('12345678')
+    });
+
+    it('should return given string when it is not start with 0x', () => {
+      expect(trimHexPrefix('12345678')).toBe('12345678')
+    });
+  });
+});

--- a/packages/snap/src/utils/getHDNode.ts
+++ b/packages/snap/src/utils/getHDNode.ts
@@ -3,6 +3,7 @@ import {BIP32Interface} from 'bip32';
 import {BitcoinNetwork, SLIP10Node, Wallet} from '../interface';
 import {getNetwork} from '../bitcoin/getNetwork';
 import {parseLightningPath} from '../bitcoin/cryptoPath';
+import { trimHexPrefix } from '../utils/hexHelper';
 
 const CRYPTO_CURVE = 'secp256k1';
 
@@ -23,8 +24,8 @@ export const getHDNode = async (wallet: Wallet, hdPath: string) => {
     },
   })) as SLIP10Node;
 
-  const privateKeyBuffer = Buffer.from(slip10Node.privateKey, 'hex');
-  const chainCodeBuffer = Buffer.from(slip10Node.chainCode, 'hex');
+  const privateKeyBuffer = Buffer.from(trimHexPrefix(slip10Node.privateKey), 'hex');
+  const chainCodeBuffer = Buffer.from(trimHexPrefix(slip10Node.chainCode), 'hex');
   const node: BIP32Interface = bip32.fromPrivateKey(
     privateKeyBuffer,
     chainCodeBuffer,

--- a/packages/snap/src/utils/hexHelper.ts
+++ b/packages/snap/src/utils/hexHelper.ts
@@ -1,0 +1,1 @@
+export const trimHexPrefix = (key: string) => key.startsWith('0x') ? key.substring(2) : key;

--- a/packages/snap/src/utils/index.ts
+++ b/packages/snap/src/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './unitHelper';
+export * from './hexHelper';
+export * from './manageState';


### PR DESCRIPTION
Flask has [breaking change in 10.23](https://github.com/MetaMask/snaps-monorepo/discussions/1101)

> All hexadecimal values are now prefixed with 0x

Trim the `0x` prefix for keys from snap when building BIP 32 node.